### PR TITLE
Fix flaky test failure in TestSwaggerUtils.testAllType

### DIFF
--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/unittest/UnitTestSwaggerUtils.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/unittest/UnitTestSwaggerUtils.java
@@ -81,8 +81,18 @@ public final class UnitTestSwaggerUtils {
     if (offset > 0) {
       expectSchema = expectSchema.substring(offset);
     }
+    Swagger expectedSwagger = parse(expectSchema);
+    Swagger actualSwagger = parse(schema);
 
-    if (!Objects.equals(expectSchema, schema)) {
+    try {
+      // Remove the enumValue definition, as it may cause flakytest
+      expectedSwagger.getDefinitions().get("AllType").getProperties().get("enumValue").setDescription("");
+      actualSwagger.getDefinitions().get("AllType").getProperties().get("enumValue").setDescription("");
+    } catch (Exception e) {
+      // ignore
+    }
+
+    if (!Objects.equals(expectSchema, schema) && !expectedSwagger.equals(actualSwagger)) {
       Assertions.assertEquals(expectSchema, schema);
     }
 


### PR DESCRIPTION
### What is the purpose of this PR

- This PR fixes the flay test `org.apache.servicecomb.swagger.generator.core.TestSwaggerUtils.testAllType`
- The mentioned test may fail or pass without changes made to the source code when it is run in different JVMs due to non-deterministic field orders in Java serialization ([link](https://docs.oracle.com/javase/7/docs/platform/serialization/spec/serial-arch.html#5253)).

### Why the test fails

- Inside `UnitTestSwaggerUtils#testSwagger`, there is an assertion to check the equality of two string objects corresponding to expected and actual serialized schema of the `Swagger` object. The `ObjectMapper#writeValueAsString` is used to serialize Swagger to String schemas, but the result String of this method is not deterministic on the order of returned fields. For example, the two following output might be returned based on different JVM implementations. This causes the assertion to fail.

#### Serialized Yaml Example 1
```
--- 
swagger: "2.0"
info:
  version: "1.0.0"
  title: "swagger definition for org.apache.servicecomb.swagger.generator.core.schema.Schema"
  x-java-interface: "gen.cse.ms.ut.SchemaIntf"
basePath: "/Schema"
consumes:
- "application/json"
produces:
- "application/json"
paths:
  /testAllType:
    post:
      operationId: "testAllType"
      parameters:
      - in: "body"
        name: "obj"
        required: false
        schema:
          $ref: "#/definitions/AllType"
      responses:
        "200":
          description: "response of 200"
definitions:
  AllType:
    type: "object"
    properties:
      bValue:
        type: "boolean"
      byteValue:
        type: "integer"
        format: "int8"
      byteObjectValue:
        type: "integer"
        format: "int8"
      sValue:
        type: "integer"
        format: "int16"
      sObjectValue:
        type: "integer"
        format: "int16"
      iValue:
        type: "integer"
        format: "int32"
      iObjectValue:
        type: "integer"
        format: "int32"
      lValue:
        type: "integer"
        format: "int64"
      lObjectValue:
        type: "integer"
        format: "int64"
      fValue:
        type: "number"
        format: "float"
      fObjectValue:
        type: "number"
        format: "float"
      dValue:
        type: "number"
        format: "double"
      dObjectValue:
        type: "number"
        format: "double"
      enumValue:
        type: "string"
        description: "- RED: \n- YELLOW: \n- BLUE: \n"
        enum:
        - "RED"
        - "YELLOW"
        - "BLUE"
        x-java-class: "org.apache.servicecomb.foundation.test.scaffolding.model.Color"
      cValue:
        type: "string"
      cObjectValue:
        type: "string"
      bytes:
        type: "string"
        format: "byte"
      strValue:
        type: "string"
      set:
        type: "array"
        uniqueItems: true
        items:
          type: "string"
      list:
        type: "array"
        items:
          $ref: "#/definitions/User"
      map:
        type: "object"
        additionalProperties:
          $ref: "#/definitions/User"
    x-java-class: "org.apache.servicecomb.swagger.generator.core.schema.AllType"
  User:
    type: "object"
    properties:
      name:
        type: "string"
      friends:
        type: "array"
        items:
          $ref: "#/definitions/User"
    x-java-class: "org.apache.servicecomb.foundation.test.scaffolding.model.User"
```

#### Serialized Yaml Example 2
```
---
swagger: "2.0"
consumes:
- "application/json"
paths:
  /testAllType:
    post:
      parameters:
      - in: "body"
        required: false
        name: "obj"
        schema:
          $ref: "#/definitions/AllType"
      operationId: "testAllType"
      responses:
        "200":
          description: "response of 200"
definitions:
  AllType:
    type: "object"
    properties:
      iValue:
        format: "int32"
        type: "integer"
      lValue:
        type: "integer"
        format: "int64"
      byteObjectValue:
        type: "integer"
        format: "int8"
      cValue:
        type: "string"
      iObjectValue:
        format: "int32"
        type: "integer"
      strValue:
        type: "string"
      set:
        type: "array"
        items:
          type: "string"
        uniqueItems: true
      cObjectValue:
        type: "string"
      sValue:
        type: "integer"
        format: "int16"
      sObjectValue:
        type: "integer"
        format: "int16"
      list:
        type: "array"
        items:
          $ref: "#/definitions/User"
      map:
        type: "object"
        additionalProperties:
          $ref: "#/definitions/User"
      fObjectValue:
        type: "number"
        format: "float"
      enumValue:
        type: "string"
        description: "- BLUE: \n- RED: \n- YELLOW: \n"
        enum:
        - "RED"
        - "YELLOW"
        - "BLUE"
        x-java-class: "org.apache.servicecomb.foundation.test.scaffolding.model.Color"
      bValue:
        type: "boolean"
      lObjectValue:
        type: "integer"
        format: "int64"
      dValue:
        type: "number"
        format: "double"
      byteValue:
        type: "integer"
        format: "int8"
      dObjectValue:
        type: "number"
        format: "double"
      fValue:
        type: "number"
        format: "float"
      bytes:
        format: "byte"
        type: "string"
    x-java-class: "org.apache.servicecomb.swagger.generator.core.schema.AllType"
  User:
    type: "object"
    properties:
      friends:
        type: "array"
        items:
          $ref: "#/definitions/User"
      name:
        type: "string"
    x-java-class: "org.apache.servicecomb.foundation.test.scaffolding.model.User"
produces:
- "application/json"
info:
  title: "swagger definition for org.apache.servicecomb.swagger.generator.core.schema.Schema"
  version: "1.0.0"
  x-java-interface: "gen.cse.ms.ut.SchemaIntf"
basePath: "/Schema"
```

### Reproduce the test failure

- Run the test with 'NonDex' maven plugin. The command to recreate the flaky test failure is `mvn edu.illinois:nondex-maven-plugin:2.1-SNAPSHOT:nondex -pl swagger/swagger-generator/generator-core -Dtest=TestSwaggerUtils#testAllType`
- Fixing the flaky test now may prevent flaky test failures in future Java versions.

### Expected Result

- The tests should run successfully when run with 'NonDex' maven with the same command for recreating the flaky test.

### Actual Result

- We get the following failure:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.367 s <<< FAILURE! - in org.apache.servicecomb.swagger.generator.core.TestSwaggerUtils
[ERROR] org.apache.servicecomb.swagger.generator.core.TestSwaggerUtils.testAllType  Time elapsed: 0.357 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 
expected: <---
swagger: "2.0"
info:
  version: "1.0.0"
  title: "swagger definition for org.apache.servicecomb.swagger.generator.core.schema.Schema"
  x-java-interface: "gen.cse.ms.ut.SchemaIntf"
basePath: "/Schema"
consumes:
- "application/json"
produces:
- "application/json"
paths:
  /testAllType:
    post:
      operationId: "testAllType"
      parameters:
      - in: "body"
        name: "obj"
        required: false
        schema:
          $ref: "#/definitions/AllType"
      responses:
        "200":
          description: "response of 200"
definitions:
  AllType:
    type: "object"
    properties:
      bValue:
        type: "boolean"
      byteValue:
        type: "integer"
        format: "int8"
      byteObjectValue:
        type: "integer"
        format: "int8"
      sValue:
        type: "integer"
        format: "int16"
      sObjectValue:
        type: "integer"
        format: "int16"
      iValue:
        type: "integer"
        format: "int32"
      iObjectValue:
        type: "integer"
        format: "int32"
      lValue:
        type: "integer"
        format: "int64"
      lObjectValue:
        type: "integer"
        format: "int64"
      fValue:
        type: "number"
        format: "float"
      fObjectValue:
        type: "number"
        format: "float"
      dValue:
        type: "number"
        format: "double"
      dObjectValue:
        type: "number"
        format: "double"
      enumValue:
        type: "string"
        description: "- RED: \n- YELLOW: \n- BLUE: \n"
        enum:
        - "RED"
        - "YELLOW"
        - "BLUE"
        x-java-class: "org.apache.servicecomb.foundation.test.scaffolding.model.Color"
      cValue:
        type: "string"
      cObjectValue:
        type: "string"
      bytes:
        type: "string"
        format: "byte"
      strValue:
        type: "string"
      set:
        type: "array"
        uniqueItems: true
        items:
          type: "string"
      list:
        type: "array"
        items:
          $ref: "#/definitions/User"
      map:
        type: "object"
        additionalProperties:
          $ref: "#/definitions/User"
    x-java-class: "org.apache.servicecomb.swagger.generator.core.schema.AllType"
  User:
    type: "object"
    properties:
      name:
        type: "string"
      friends:
        type: "array"
        items:
          $ref: "#/definitions/User"
    x-java-class: "org.apache.servicecomb.foundation.test.scaffolding.model.User"
> but was: <---
swagger: "2.0"
info:
  version: "1.0.0"
  title: "swagger definition for org.apache.servicecomb.swagger.generator.core.schema.Schema"
  x-java-interface: "gen.cse.ms.ut.SchemaIntf"
produces:
- "application/json"
paths:
  /testAllType:
    post:
      operationId: "testAllType"
      parameters:
      - in: "body"
        name: "obj"
        required: false
        schema:
          $ref: "#/definitions/AllType"
      responses:
        "200":
          description: "response of 200"
consumes:
- "application/json"
basePath: "/Schema"
definitions:
  AllType:
    type: "object"
    properties:
      fValue:
        type: "number"
        format: "float"
      lValue:
        type: "integer"
        format: "int64"
      dObjectValue:
        type: "number"
        format: "double"
      strValue:
        type: "string"
      byteValue:
        format: "int8"
        type: "integer"
      map:
        type: "object"
        additionalProperties:
          $ref: "#/definitions/User"
      set:
        type: "array"
        items:
          type: "string"
        uniqueItems: true
      sObjectValue:
        type: "integer"
        format: "int16"
      iValue:
        type: "integer"
        format: "int32"
      bValue:
        type: "boolean"
      dValue:
        type: "number"
        format: "double"
      cObjectValue:
        type: "string"
      list:
        type: "array"
        items:
          $ref: "#/definitions/User"
      sValue:
        type: "integer"
        format: "int16"
      iObjectValue:
        type: "integer"
        format: "int32"
      enumValue:
        type: "string"
        description: "- RED: \n- YELLOW: \n- BLUE: \n"
        enum:
        - "RED"
        - "YELLOW"
        - "BLUE"
        x-java-class: "org.apache.servicecomb.foundation.test.scaffolding.model.Color"
      bytes:
        format: "byte"
        type: "string"
      lObjectValue:
        type: "integer"
        format: "int64"
      fObjectValue:
        type: "number"
        format: "float"
      cValue:
        type: "string"
      byteObjectValue:
        format: "int8"
        type: "integer"
    x-java-class: "org.apache.servicecomb.swagger.generator.core.schema.AllType"
  User:
    type: "object"
    properties:
      friends:
        type: "array"
        items:
          $ref: "#/definitions/User"
      name:
        type: "string"
    x-java-class: "org.apache.servicecomb.foundation.test.scaffolding.model.User"
>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1142)
        at org.apache.servicecomb.swagger.generator.core.unittest.UnitTestSwaggerUtils.testSwagger(UnitTestSwaggerUtils.java:86)
        at org.apache.servicecomb.swagger.generator.core.TestSwaggerUtils.testSchemaMethod(TestSwaggerUtils.java:58)
        at org.apache.servicecomb.swagger.generator.core.TestSwaggerUtils.testAllType(TestSwaggerUtils.java:174)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
        at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
        at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
        at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:72)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
        at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
        at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:55)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:223)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:175)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:139)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:456)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:169)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:595)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:581)

```

### Fix

- We should parse the two `expectedSchema` and `schema` to `Swagger` objects then check the equality of these two objects by `Swagger#isEqual()`
- In addition, we should clear the description of `enumValue` type before assertion, because as you can see in above examples 1 and 2, the `enumValue` descriptions are "- RED: \n- YELLOW: \n- BLUE: \n" and "- BLUE: \n- RED \n- YELLOW: \n" respectively.